### PR TITLE
Updated gulp-sass version to 4.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "gulp-npm-dist": "^1.0.3",
         "gulp-plumber": "1.2.1",
         "gulp-rename": "1.4.0",
-        "gulp-sass": "4.0.2",
+        "gulp-sass": "4.1.0",
         "gulp-sourcemaps": "2.6.5",
         "gulp-uglify": "3.0.2",
         "gulp-wait": "0.0.2",


### PR DESCRIPTION
I was setting up impact design system today and it failed on npm install because it wasn't able to find node-sass Github repo for downloading binary. This commit fixes the same by updating gulp-sass version.