### PR TITLE
Update version locks (fix issues #21 and #24)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         },
         "node_modules/@fortawesome/fontawesome-free": {
             "version": "5.11.2",
-            "resolved": "https://npm.fontawesome.com/@fortawesome/fontawesome-free/-/5.11.2/fontawesome-free-5.11.2.tgz",
+            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.11.2.tgz",
             "integrity": "sha512-XiUPoS79r1G7PcpnNtq85TJ7inJWe0v+b5oZJZKb0pGHNIV6+UiNeQWiFGmuQ0aj7GEhnD/v9iqxIsjuRKtEnQ==",
             "engines": {
                 "node": ">=6"
@@ -4879,22 +4879,20 @@
             }
         },
         "node_modules/node-gyp": {
-            "version": "3.8.0",
-            "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",
-            "integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-9.1.0.tgz",
+            "integrity": "sha512-HkmN0ZpQJU7FLbJauJTHkHlSVAXlNGDAzH/VYFZGDOnFyn/Na3GlNJfkudmufOdS6/jNFhy88ObzL7ERz9es1g==",
             "dependencies": {
-                "fstream": "^1.0.0",
-                "glob": "^7.0.3",
-                "graceful-fs": "^4.1.2",
-                "mkdirp": "^0.5.0",
-                "nopt": "2 || 3",
-                "npmlog": "0 || 1 || 2 || 3 || 4",
-                "osenv": "0",
-                "request": "^2.87.0",
-                "rimraf": "2",
-                "semver": "~5.3.0",
-                "tar": "^2.0.0",
-                "which": "1"
+                "env-paths": "^2.2.0",
+                "glob": "^7.1.4",
+                "graceful-fs": "^4.2.6",
+                "make-fetch-happen": "^10.0.3",
+                "nopt": "^5.0.0",
+                "npmlog": "^6.0.0",
+                "rimraf": "^3.0.2",
+                "semver": "^7.3.5",
+                "tar": "^6.1.2",
+                "which": "^2.0.2"
             },
             "bin": {
                 "node-gyp": "bin/node-gyp.js"
@@ -4927,7 +4925,7 @@
                 "meow": "^3.7.0",
                 "mkdirp": "^0.5.1",
                 "nan": "^2.13.2",
-                "node-gyp": "^3.8.0",
+                "node-gyp": "^9.1.0",
                 "npmlog": "^4.0.0",
                 "request": "^2.88.0",
                 "sass-graph": "2.2.5",
@@ -13231,7 +13229,7 @@
     "dependencies": {
         "@fortawesome/fontawesome-free": {
             "version": "5.11.2",
-            "resolved": "https://npm.fontawesome.com/@fortawesome/fontawesome-free/-/5.11.2/fontawesome-free-5.11.2.tgz",
+            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.11.2.tgz",
             "integrity": "sha512-XiUPoS79r1G7PcpnNtq85TJ7inJWe0v+b5oZJZKb0pGHNIV6+UiNeQWiFGmuQ0aj7GEhnD/v9iqxIsjuRKtEnQ=="
         },
         "@gulp-sourcemaps/identity-map": {
@@ -17256,22 +17254,20 @@
             }
         },
         "node-gyp": {
-            "version": "3.8.0",
-            "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",
-            "integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-9.1.0.tgz",
+            "integrity": "sha512-HkmN0ZpQJU7FLbJauJTHkHlSVAXlNGDAzH/VYFZGDOnFyn/Na3GlNJfkudmufOdS6/jNFhy88ObzL7ERz9es1g==",
             "requires": {
-                "fstream": "^1.0.0",
-                "glob": "^7.0.3",
-                "graceful-fs": "^4.1.2",
-                "mkdirp": "^0.5.0",
-                "nopt": "2 || 3",
-                "npmlog": "0 || 1 || 2 || 3 || 4",
-                "osenv": "0",
-                "request": "^2.87.0",
-                "rimraf": "2",
-                "semver": "~5.3.0",
-                "tar": "^2.0.0",
-                "which": "1"
+                "env-paths": "^2.2.0",
+                "glob": "^7.1.4",
+                "graceful-fs": "^4.2.6",
+                "make-fetch-happen": "^10.0.3",
+                "nopt": "^5.0.0",
+                "npmlog": "^6.0.0",
+                "rimraf": "^3.0.2",
+                "semver": "^7.3.5",
+                "tar": "^6.1.2",
+                "which": "^2.0.2"
             }
         },
         "node-releases": {
@@ -17297,7 +17293,7 @@
                 "meow": "^3.7.0",
                 "mkdirp": "^0.5.1",
                 "nan": "^2.13.2",
-                "node-gyp": "^3.8.0",
+                "node-gyp": "^9.1.0",
                 "npmlog": "^4.0.0",
                 "request": "^2.88.0",
                 "sass-graph": "2.2.5",


### PR DESCRIPTION
``npm install`` is currently failing because of two reasons, this PR should help fix both.

* Replace FontAwesome's URL from its private NPM registry to the public NPM registry so that login is no longer required (#21)
* Update node-gyp and its requirements to the latest version (9.1.0) so that no error is presented (#24)

I was able to finish with ``npm install`` and build with Gulp with those changes, and everything seems to be fine, feel free to test them out and see if everything works as intended.